### PR TITLE
Update to canonical structure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@
 #
 #*.png binary
 
-test/upstream symlink=dir
-perf/upstream symlink=dir
-example/upstream symlink=dir
+range-v3/include symlink=dir
+test/src symlink=dir
+perf/src symlink=dir
+example/src symlink=dir

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bdep/
+.vs/
 
 # Local default options files.
 #

--- a/build2/export.build2
+++ b/build2/export.build2
@@ -1,6 +1,6 @@
 $out_root/
 {
-  include ./
+  include range-v3/
 }
 
-export $out_root/$import.target
+export $out_root/range-v3/$import.target

--- a/build2file
+++ b/build2file
@@ -1,62 +1,10 @@
-./ : manifest test/ example/
+./: range-v3/ manifest
 
 # Documentation
-./ : upstream/doc{README.md} upstream/doc/doc{**.md}
-
-intf_libs = # Interface dependencies.
-impl_libs = # Implementation dependencies.
-#import impl_libs += libhello%lib{hello}
-
-./ : lib{range-v3}: upstream/include/{hxx ixx txx}{**} $impl_libs $intf_libs
-
-# Include the generated version header into the distribution (so that we don't
-# pick up an installed one) and don't remove it when cleaning in src (so that
-# clean results in a state identical to distributed).
 #
-lib{range-v3} : upstream/include/range/v3/hxx{version}
-upstream/include/range/v3/
-{
-  hxx{version}: $src_root/upstream/in{version} $src_root/manifest
-  {
-    dist  = true
-    clean = ($src_root != $out_root)
-    in.symbol = '@'
-    RANGE_V3_MAJOR = $version.major
-    RANGE_V3_MINOR = $version.minor
-    RANGE_V3_PATCHLEVEL = $version.patch
-  }
-
-}
-
-
-include_dirs_flags = "-I$src_root/upstream/include/std" "-I$src_root/upstream/include"  "-I$out_root/upstream/include"
-
-# Build options.
-#
-cxx.poptions =+ $include_dirs_flags
-
-# Export options.
-#
-lib{range-v3}:
-{
-  cxx.export.poptions = $include_dirs_flags
-  cxx.export.libs = $intf_libs
-}
-
-
-upstream/include/
-{
-  # Install into the range-v3/ subdirectory of, say, /usr/include/
-  # recreating subdirectories.
-  #
-  {hxx ixx txx}{*}:
-  {
-  install         = include/ # Header paths are already containing include/range/...
-  install.subdirs = true
-  }
-}
+./: doc{upstream/README.md upstream/doc/**.md}
 
 # Don't install tests or examples.
 #
-test/: install = false
-example/: install = false
+#test/: install = false
+#example/: install = false

--- a/build2file
+++ b/build2file
@@ -1,5 +1,5 @@
-./: range-v3/ test/ example/ manifest
-#{*/ -build/ -upstream/} manifest
+# NOTE: enabling perf would require Google Benchmark dependency
+./: {*/ -build2/ -upstream/ -perf/} manifest
 
 # Documentation
 #
@@ -7,5 +7,6 @@
 
 # Don't install tests or examples.
 #
-#test/: install = false
-#example/: install = false
+test/: install = false
+perf/: install = false
+example/: install = false

--- a/build2file
+++ b/build2file
@@ -1,4 +1,5 @@
-./: range-v3/ manifest
+./: range-v3/ test/ manifest
+#{*/ -build/ -upstream/} manifest
 
 # Documentation
 #

--- a/build2file
+++ b/build2file
@@ -1,4 +1,4 @@
-./: range-v3/ test/ manifest
+./: range-v3/ test/ example/ manifest
 #{*/ -build/ -upstream/} manifest
 
 # Documentation

--- a/example/build2file
+++ b/example/build2file
@@ -1,16 +1,15 @@
 
-# import rangev3 = range-v3%lib{range-v3}
 import rangev3 = lib{range-v3}
 
 exe{*} : test = true
 
 # TODO: add an option to activate the calendar test (requires boost libraries as an optional dependency)
-example_sources = $src_root/upstream/example/{cxx}{** -calendar}
+example_sources = $src_base/src/{cxx}{** -calendar}
 
 for example_cpp : $example_sources
 {
     dot_path = $regex.replace($directory($example_cpp), '\\', '/')
-    dot_path = $regex.replace($dot_path, '^(.*?)upstream\/example\/', '')
+    dot_path = $regex.replace($dot_path, '^(.*?)example\/src\/', '')
     dot_path = $regex.replace($dot_path, '/', '.')
     example_name = "example.$dot_path$name($example_cpp)$exe_ext"
     # info "-> $example_name"

--- a/example/src
+++ b/example/src
@@ -1,0 +1,1 @@
+./../upstream/example

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 
 : 1
 name: range-v3
-version: 0.12.0+1
+version: 0.12.0+2
 summary: Range library for C++14/17/20.
 license: Boost Software License
 description-file: upstream/README.md
@@ -11,15 +11,16 @@ email: eniebler@boost.org
 package-url: https://github.com/build2-packaging/range-v3
 package-email: mjklaim@gmail.com
 
-depends: * build2 >= 0.14.0
-depends: * bpkg >= 0.14.0
+depends: * build2 >= 0.15.0
+depends: * bpkg >= 0.15.0
 
 requires: c++14 | c++17 | c++20
 builds: default experimental          ; Only modern compilers are supported.
 build-include: windows**-msvc_16**    ; Only use msvc on Windows.
+build-include: windows**-msvc_17**    ; Only use msvc on Windows.
 build-exclude: windows**              ; Only use msvc on Windows.
 build-exclude: **clang_13**           ; Works with C++14 to 20 only, not C++23 yet.
 build-exclude: **clang_14**           ; Works with C++14 to 20 only, not C++23 yet.
-build-exclude: **emcc**         ; Works with C++14 to 20 only, not C++23 yet.
+build-exclude: **emcc**               ; Works with C++14 to 20 only, not C++23 yet.
 
 

--- a/perf/build2file
+++ b/perf/build2file
@@ -1,10 +1,9 @@
 
-# import rangev3 = range-v3%lib{range-v3}
 import rangev3 = lib{range-v3}
 
 exe{*} : test = true
 
-perf_dir = $src_root/upstream/perf
+perf_dir = $src_base/src
 
 for test_cpp : $perf_dir/cxx{*}
 {

--- a/perf/src
+++ b/perf/src
@@ -1,0 +1,1 @@
+./../upstream/perf

--- a/range-v3/build2file
+++ b/range-v3/build2file
@@ -3,28 +3,6 @@ impl_libs = # Implementation dependencies.
 
 ./: lib{range-v3}: include/{hxx ixx txx}{**} $impl_libs $intf_libs
 
-# Include the generated version header into the distribution (so that we don't
-# pick up an installed one) and don't remove it when cleaning in src (so that
-# clean results in a state identical to distributed).
-#
-lib{range-v3}: include/range/v3/hxx{version}
-include/range/v3/
-{
-  # @cja struggling to see how to do this in a nice way, but anyway, what is reason for this? seems version.hpp is already set in upstream.
-  hxx{version}: $src_base/../../../in{version} $src_root/manifest
-   #$src_base/in{version} $src_root/manifest
-  {
-    dist = true
-    clean = ($src_root != $out_root)
-    in.symbol = '@'
-    RANGE_V3_MAJOR = $version.major
-    RANGE_V3_MINOR = $version.minor
-    RANGE_V3_PATCHLEVEL = $version.patch
-  }
-}
-
-
-# @cja note: removed -I for /include/std, not sure what reason was for it's previous inclusion?
 include_dirs_flags = "-I$src_base/include" "-I$out_base/include"
 
 # Build options.
@@ -38,7 +16,6 @@ lib{range-v3}:
   cxx.export.poptions = $include_dirs_flags
   cxx.export.libs = $intf_libs
 }
-
 
 include/
 {

--- a/range-v3/build2file
+++ b/range-v3/build2file
@@ -24,8 +24,8 @@ include/range/v3/
 }
 
 
-# @cja to verify - why /std? 
-include_dirs_flags = "-I$src_base/include" "-I$out_base/include" # "-I$src_base/include/std"
+# @cja note: removed -I for /include/std, not sure what reason was for it's previous inclusion?
+include_dirs_flags = "-I$src_base/include" "-I$out_base/include"
 
 # Build options.
 #

--- a/range-v3/build2file
+++ b/range-v3/build2file
@@ -15,7 +15,6 @@ include/range/v3/
    #$src_base/in{version} $src_root/manifest
   {
     dist = true
-    # @cja should this now become _src? don't know what this is about.
     clean = ($src_root != $out_root)
     in.symbol = '@'
     RANGE_V3_MAJOR = $version.major
@@ -26,8 +25,7 @@ include/range/v3/
 
 
 # @cja to verify - why /std? 
-include_dirs_flags = "-I$src_base/include/std" "-I$src_base/include"  "-I$out_base/include"
- #"-I$src_root/upstream/include/std" "-I$src_root/upstream/include"  "-I$out_root/upstream/include"
+include_dirs_flags = "-I$src_base/include" "-I$out_base/include" # "-I$src_base/include/std"
 
 # Build options.
 #

--- a/range-v3/build2file
+++ b/range-v3/build2file
@@ -1,0 +1,55 @@
+intf_libs = # Interface dependencies.
+impl_libs = # Implementation dependencies.
+
+./: lib{range-v3}: include/{hxx ixx txx}{**} $impl_libs $intf_libs
+
+# Include the generated version header into the distribution (so that we don't
+# pick up an installed one) and don't remove it when cleaning in src (so that
+# clean results in a state identical to distributed).
+#
+lib{range-v3}: include/range/v3/hxx{version}
+include/range/v3/
+{
+  # @cja struggling to see how to do this in a nice way, but anyway, what is reason for this? seems version.hpp is already set in upstream.
+  hxx{version}: $src_base/../../../in{version} $src_root/manifest
+   #$src_base/in{version} $src_root/manifest
+  {
+    dist = true
+    # @cja should this now become _src? don't know what this is about.
+    clean = ($src_root != $out_root)
+    in.symbol = '@'
+    RANGE_V3_MAJOR = $version.major
+    RANGE_V3_MINOR = $version.minor
+    RANGE_V3_PATCHLEVEL = $version.patch
+  }
+}
+
+
+# @cja to verify - why /std? 
+include_dirs_flags = "-I$src_base/include/std" "-I$src_base/include"  "-I$out_base/include"
+ #"-I$src_root/upstream/include/std" "-I$src_root/upstream/include"  "-I$out_root/upstream/include"
+
+# Build options.
+#
+cxx.poptions =+ $include_dirs_flags
+
+# Export options.
+#
+lib{range-v3}:
+{
+  cxx.export.poptions = $include_dirs_flags
+  cxx.export.libs = $intf_libs
+}
+
+
+include/
+{
+  # Install into the range-v3/ subdirectory of, say, /usr/include/
+  # recreating subdirectories.
+  #
+  {hxx ixx txx}{*}:
+  {
+    install         = include/ # Header paths are already containing include/range/...
+    install.subdirs = true
+  }
+}

--- a/range-v3/include
+++ b/range-v3/include
@@ -1,0 +1,1 @@
+C:/Coding/Build2/third-party-packaging/build2-packaging/range-v3/upstream/include/

--- a/range-v3/include
+++ b/range-v3/include
@@ -1,1 +1,1 @@
-C:/Coding/Build2/third-party-packaging/build2-packaging/range-v3/upstream/include/
+./../upstream/include

--- a/range-v3/version.hpp.in
+++ b/range-v3/version.hpp.in
@@ -1,0 +1,1 @@
+C:/Coding/Build2/third-party-packaging/build2-packaging/range-v3/upstream/version.hpp.in

--- a/range-v3/version.hpp.in
+++ b/range-v3/version.hpp.in
@@ -1,1 +1,0 @@
-../upstream/version.hpp.in

--- a/range-v3/version.hpp.in
+++ b/range-v3/version.hpp.in
@@ -1,1 +1,1 @@
-C:/Coding/Build2/third-party-packaging/build2-packaging/range-v3/upstream/version.hpp.in
+../upstream/version.hpp.in

--- a/test/build2file
+++ b/test/build2file
@@ -37,9 +37,10 @@ for test_cpp : $tests_sources
 if($cxx.id != 'msvc')
 {
     # Enable all warnings:
-    # cja my clang 15.0 doesn't like -pedantic-errors...
+    # cja my clang 15.0 pre-release on Windows doesn't like -pedantic-errors...
     # further, getting warning spam from -Wgnu-line-marker, not sure why.
-    cc.coptions += -pedantic #-pedantic-errors
+    # clang windows builds remain off in package manifest
+    cc.coptions += -pedantic -pedantic-errors
     if($cxx.id == 'clang')
     {
         cc.coptions += -Weverything 

--- a/test/build2file
+++ b/test/build2file
@@ -38,6 +38,7 @@ if($cxx.id != 'msvc')
 {
     # Enable all warnings:
     # cja my clang 15.0 doesn't like -pedantic-errors...
+    # further, getting warning spam from -Wgnu-line-marker, not sure why.
     cc.coptions += -pedantic #-pedantic-errors
     if($cxx.id == 'clang')
     {

--- a/test/build2file
+++ b/test/build2file
@@ -1,11 +1,10 @@
 
-# import rangev3 = range-v3%lib{range-v3}
 import rangev3 = lib{range-v3}
 
 exe{*} : test = true
 
 # TODO: add an option to handle coroutine tests and remove the exception to not build experimental tests
-test_src_dir = $src_root/upstream/test
+test_src_dir = $src_base/src
 
 # skip files which are not built upstream (see cmake files), but take all the tests otherwise
 tests_to_skip = 'algorithm/partition_move' 'algorithm/copy_n' 'algorithm/fill_n'
@@ -24,12 +23,11 @@ test_headers = $test_src_dir/{hxx}{**}
 
 for test_cpp : $tests_sources
 {
-
     dot_path = $regex.replace($directory($test_cpp), '\\', '/')
-    dot_path = $regex.replace($dot_path, '^(.*?)upstream\/test\/', '')
+    dot_path = $regex.replace($dot_path, '^(.*?)test\/src\/', '')
     dot_path = $regex.replace($dot_path, '/', '.')
     test_name = "test.$dot_path$name($test_cpp)"
-    # info "-> $test_name"
+    #info "-> $test_name"
     ./ : exe{$test_name...} : $test_cpp $rangev3 $test_headers
 }
 
@@ -39,7 +37,8 @@ for test_cpp : $tests_sources
 if($cxx.id != 'msvc')
 {
     # Enable all warnings:
-    cc.coptions += -pedantic -pedantic-errors
+    # cja my clang 15.0 doesn't like -pedantic-errors...
+    cc.coptions += -pedantic #-pedantic-errors
     if($cxx.id == 'clang')
     {
         cc.coptions += -Weverything 

--- a/test/src
+++ b/test/src
@@ -1,1 +1,1 @@
-C:/Coding/Build2/third-party-packaging/build2-packaging/range-v3/upstream/test/
+./../upstream/test

--- a/test/src
+++ b/test/src
@@ -1,0 +1,1 @@
+C:/Coding/Build2/third-party-packaging/build2-packaging/range-v3/upstream/test/


### PR DESCRIPTION
One small thing I'm a bit unclear on is best way of arranging the symlinks. Looking back I feel I might have been a bit inconsistent there. In `range-v3/range-v3`, there's now a symlink `include -> upstream/include`, so essentially that directory is mapping directly to `upstream`; whereas in `range-v3/test` I have a symlink `src -> upstream/test`. This can be easily changed of course, I'm just wondering if there is any best practice here though. Is the idea to try to map subdirectories of the package to subdirectories of upstream, or is that not really relevant and it's just a case of making symlinks to whatever is needed, with reasonable names?